### PR TITLE
Visual fix

### DIFF
--- a/src/components/pages/account/sections/AccountRewards.tsx
+++ b/src/components/pages/account/sections/AccountRewards.tsx
@@ -28,7 +28,7 @@ export function AccountRewards() {
   } = useGetInvoices(query, !!userId);
 
   const options = useMemo(() => {
-    return ['All', 'Paid', 'In progress', 'Contact Us'].map((entry) => {
+    return ['All', 'Paid', 'In progress', 'Error'].map((entry) => {
       return { label: entry } as HasLabel;
     });
   }, []);
@@ -41,7 +41,7 @@ export function AccountRewards() {
         return [InvoiceStatus.Unpaid];
       case 'Paid':
         return [InvoiceStatus.Paid];
-      case 'Contact Us':
+      case 'Error':
         return [InvoiceStatus.Error];
       default:
         break;


### PR DESCRIPTION
Fixed the "Contact Us" string under the rewards section. Probably just a copy and paste error.